### PR TITLE
Add crystal_lib

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
         add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-4.0 main" \
          && curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
          && apt-get update \
-         && apt-get install -y llvm-4.0
+         && apt-get install -y llvm-4.0 libclang-4.0-dev
 
         # bats
         cd /vagrant
@@ -42,7 +42,7 @@ Vagrant.configure("2") do |config|
         dnf -y install git
         dnf -y install gmp-devel libbsd-devel libedit-devel libevent-devel libxml2-devel \
                        libyaml-devel llvm-devel openssl-devel readline-devel redhat-rpm-config
-        dnf -y install sqlite-devel postgresql
+        dnf -y install sqlite-devel postgresql libclang-4.0-dev
 
         # bats
         cd /vagrant

--- a/bats/20-crystal-ext.bats
+++ b/bats/20-crystal-ext.bats
@@ -7,4 +7,8 @@
   popd
 }
 
-# TODO: crystal_lib
+@test "crystal_lib specs" {
+  pushd $REPOS_DIR/crystal-lang/crystal_lib
+  crystal spec
+  popd
+}

--- a/docker/Dockerfile-debian-deb
+++ b/docker/Dockerfile-debian-deb
@@ -10,7 +10,7 @@ RUN apt-get update \
 RUN add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-4.0 main" \
  && curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
  && apt-get update \
- && apt-get install -y llvm-4.0
+ && apt-get install -y llvm-4.0 libclang-4.0-dev
 
 ARG crystal_deb
 COPY ${crystal_deb} /tmp/crystal.deb

--- a/docker/Dockerfile-debian-targz
+++ b/docker/Dockerfile-debian-targz
@@ -10,7 +10,7 @@ RUN apt-get update \
 RUN add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-4.0 main" \
  && curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
  && apt-get update \
- && apt-get install -y llvm-4.0
+ && apt-get install -y llvm-4.0 libclang-4.0-dev
 
 ARG crystal_targz
 COPY ${crystal_targz} /tmp/crystal.tar.gz

--- a/docker/Dockerfile-docker-build
+++ b/docker/Dockerfile-docker-build
@@ -2,7 +2,8 @@ ARG docker_image
 FROM ${docker_image}
 
 RUN apt-get update \
- && apt-get install -y libsqlite3-dev postgresql-client
+ && apt-get install -y libsqlite3-dev postgresql-client libclang-4.0-dev \
+ && ln -s libclang-4.0.so.1 /usr/lib/x86_64-linux-gnu/libclang.so
 
 ENV REPOS_DIR /repos
 ADD ./scripts /scripts

--- a/scripts/10-clone-repos.sh
+++ b/scripts/10-clone-repos.sh
@@ -28,6 +28,8 @@ function gh_clone {
 
 gh_clone crystal-lang/crystal
 
+gh_clone crystal-lang/crystal_lib
+
 gh_clone crystal-lang/crystal-db
 gh_clone crystal-lang/crystal-mysql
 gh_clone crystal-lang/crystal-sqlite3


### PR DESCRIPTION
The libclang-dev is used by crystal-lib.  Note that it's important to install the same version as the installed llvm, otherwise you get segmentation faults.

---

I ran this locally with the following make targets and all passed (provided I bump the crystal_versions to 0.26.1 - failures were expected with 0.25.0)

- `make local_darwin`
- `make docker_build`
- `make docker_debian8_deb`
- `make docker_debian9_deb`
- `make docker_debian8_targz`

I am unable to test the Vagrant changes, because I don't have Vagrant locally.

@bcardiff Please review.