### PR TITLE
Add LavinMQ

### DIFF
--- a/setup/macos-all.bash
+++ b/setup/macos-all.bash
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-brew install libmagic
+brew install libmagic lz4 etcd
 

--- a/setup/ubuntu-24.04.bash
+++ b/setup/ubuntu-24.04.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 sudo apt-get update && \
-  sudo apt-get install -y libmagic-dev && \
+  sudo apt-get install -y libmagic-dev etcd-server && \
   sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 

--- a/test/lavinmq.bats
+++ b/test/lavinmq.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+function setup_file() {
+  load helper/common.bash
+
+  git_checkout https://github.com/cloudamqp/lavinmq
+}
+
+function setup() {
+  load helper/common.bash
+}
+
+@test "build lavinmq" {
+  skiponwindows "not supported"
+  make all CRYSTAL_FLAGS=
+}
+
+@test "test lavinmq" {
+  skiponwindows "not supported"
+  make test
+}
+
+# bats test_tags=format
+@test "format lavinmq" {
+  crystal_format
+}


### PR DESCRIPTION
TODO:

- [ ] macOS Intel runner has a couple spec failures;
- [ ] macOS ARM runner doesn't find the `lz4` library;
- [ ] no need to install `lz4` on macOS: it's already installed;