### PR TITLE
Test formatter changes against baseline format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       crystal:
         type: string
         default: nightly
+      crystal_base:
+        type: string
+        default: latest
       shards:
         type: string
         default: nightly
@@ -49,10 +52,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: crystal-lang/install-crystal@v1
+      - name: Install baseline crystal formatter
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ github.event.inputs.crystal_base || 'latest' }}
+          destination: /tmp/crystal-baseline/
+      - name: Install test target crystal formatter
+        uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ github.event.inputs.crystal || 'nightly' }}
-          shards: ${{ github.event.inputs.shards || 'nightly' }}
 
       - name: Setup BATS
         uses: mig4/setup-bats@v1
@@ -68,3 +76,4 @@ jobs:
         env:
           WINDOWS_BASE_DIR: "/d/a"
           TERM: dumb
+          CRYSTAL_BASE: /tmp/crystal-baseline/bin/crystal

--- a/test/athena.bats
+++ b/test/athena.bats
@@ -58,6 +58,5 @@ function test_component() {
 
 # bats test_tags=format
 @test "format athena-framework/athena" {
-  skip "Installing ameba breaks shards (https://github.com/crystal-lang/test-ecosystem/pull/89#issuecomment-4089134332)"
   check_crystal_format https://github.com/athena-framework/athena
 }

--- a/test/athena.bats
+++ b/test/athena.bats
@@ -58,5 +58,6 @@ function test_component() {
 
 # bats test_tags=format
 @test "format athena-framework/athena" {
+  skip "Installing ameba breaks shards (https://github.com/crystal-lang/test-ecosystem/pull/89#issuecomment-4089134332)"
   check_crystal_format https://github.com/athena-framework/athena
 }

--- a/test/athena.bats
+++ b/test/athena.bats
@@ -55,3 +55,8 @@ function test_component() {
 @test "validator" {
   test_component "validator"
 }
+
+# bats test_tags=format
+@test "format athena-framework/athena" {
+  check_crystal_format https://github.com/athena-framework/athena
+}

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -8,6 +8,7 @@ fi
 
 EXE="${EXE:-}"
 CRYSTAL="${CRYSTAL:-crystal${EXE}}"
+CRYSTAL_BASE="${CRYSTAL_BASE:-crystal${EXE}}"
 SHARDS="${SHARDS:-shards${EXE}}"
 MAKE="${MAKE:-make${EXE}}"
 
@@ -53,8 +54,29 @@ function crystal_format() {
   }
 }
 
+function crystal_format_with_base() {
+  echo "Running '$CRYSTAL_BASE tool format' for a baseline"
+  $CRYSTAL_BASE tool format
+  git add -u
+
+  crystal_format || {
+    retval=$?
+
+    git reset --hard HEAD
+    return $retval
+  }
+
+  git diff --check || echo "Baseline formatting issues detected, but no formatting changes on top of baseline"
+  git reset --hard HEAD
+}
+
 function check_crystal_format() {
   shard_checkout "$1"
 
-  crystal_format
+  if [ "$CRYSTAL" != "$CRYSTAL_BASE" ]; then
+    crystal_format_with_base
+  else
+    crystal_format
+  fi
+
 }

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -12,13 +12,17 @@ CRYSTAL_BASE="${CRYSTAL_BASE:-crystal${EXE}}"
 SHARDS="${SHARDS:-shards${EXE}}"
 MAKE="${MAKE:-make${EXE}}"
 
+export GIT_TERMINAL_PROMPT=0
+
 function git_checkout() {
   local URL="$1"
   local TARGET="$BATS_TMPDIR/workdir/${1##*/}"
 
+  echo "==> Checking out $URL to $TARGET"
+
   if [ -d "$TARGET" ]; then
     cd "$TARGET" || exit 1
-    git checkout --force origin/HEAD
+    git -c advice.detachedHead=false checkout --force origin/HEAD
     git pull origin HEAD
     git submodule update --init
   else
@@ -26,6 +30,7 @@ function git_checkout() {
     cd "$TARGET" || exit 1
   fi
 
+  printf "==> Git version:"
   git describe --tags || git rev-parse HEAD
 }
 
@@ -43,24 +48,28 @@ function crystal_spec() {
 }
 
 function crystal_format() {
+  echo "==> Running '$CRYSTAL tool format --check'"
+
   $CRYSTAL tool format --check || {
     retval=$?
 
     # Print formatter diff
     $CRYSTAL tool format
     git diff
-
     return $retval
   }
+
+  echo
 }
 
 function crystal_format_with_base() {
-  echo "Running '$CRYSTAL_BASE tool format' for a baseline"
+  echo "==> Running '$CRYSTAL_BASE tool format' for a baseline"
   $CRYSTAL_BASE tool format
   git add -u
 
   crystal_format
 
+  echo
 
   git diff --cached --check || echo "Baseline formatting issues detected, but no formatting changes on top of baseline"
   git diff --cached
@@ -75,5 +84,4 @@ function check_crystal_format() {
   else
     crystal_format
   fi
-
 }

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -26,7 +26,7 @@ function git_checkout() {
     cd "$TARGET" || exit 1
   fi
 
-  git describe --tags
+  git describe --tags || git rev-parse HEAD
 }
 
 function shard_checkout() {
@@ -48,7 +48,7 @@ function crystal_format() {
 
     # Print formatter diff
     $CRYSTAL tool format
-    git diff && git checkout -- .
+    git diff
 
     return $retval
   }
@@ -59,14 +59,11 @@ function crystal_format_with_base() {
   $CRYSTAL_BASE tool format
   git add -u
 
-  crystal_format || {
-    retval=$?
+  crystal_format
 
-    git reset --hard HEAD
-    return $retval
-  }
 
-  git diff --check || echo "Baseline formatting issues detected, but no formatting changes on top of baseline"
+  git diff --cached --check || echo "Baseline formatting issues detected, but no formatting changes on top of baseline"
+  git diff --cached
   git reset --hard HEAD
 }
 

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -77,7 +77,7 @@ function crystal_format_with_base() {
 }
 
 function check_crystal_format() {
-  shard_checkout "$1"
+  git_checkout "$1"
 
   if [ "$CRYSTAL" != "$CRYSTAL_BASE" ]; then
     crystal_format_with_base

--- a/test/libraries.bats
+++ b/test/libraries.bats
@@ -52,6 +52,11 @@ function setup() {
   crystal_spec
 }
 
+# bats test_tags=format
+@test "format ysbaddaden/pool" {
+  check_crystal_format https://github.com/ysbaddaden/pool
+}
+
 @test "luckyframework/habitat" {
   shard_checkout https://github.com/luckyframework/habitat
 
@@ -92,6 +97,11 @@ function setup() {
   crystal_spec
 }
 
+# bats test_tags=format
+@test "format schovi/baked_file_system" {
+  check_crystal_format https://github.com/schovi/baked_file_system
+}
+
 @test "jeromegn/kilt" {
   skip "Liquid spec is broken (https://github.com/jeromegn/kilt/issues/30)"
   skiponwindows "Does not build"
@@ -100,10 +110,20 @@ function setup() {
   crystal_spec
 }
 
+# bats test_tags=format
+@test "format jeromegn/kilt" {
+  check_crystal_format https://github.com/jeromegn/kilt
+}
+
 @test "sumpycr/stumpy_core" {
   shard_checkout https://github.com/stumpycr/stumpy_core
 
   crystal_spec
+}
+
+# bats test_tags=format
+@test "format sumpycr/stumpy_core" {
+  check_crystal_format https://github.com/stumpycr/stumpy_core
 }
 
 @test "luckyframework/lucky_task" {
@@ -125,7 +145,6 @@ function setup() {
 
 # bats test_tags=format
 @test "format spider-gazelle/bindata" {
-  skip "Formatting not up to date"
   check_crystal_format https://github.com/spider-gazelle/bindata
 }
 
@@ -216,6 +235,11 @@ function setup() {
   crystal_spec
 }
 
+# bats test_tags=format
+@test "format kostya/lexbor" {
+  check_crystal_format https://github.com/kostya/lexbor
+}
+
 @test "icyleaf/halite" {
   skiponwindows "Specs are failing"
   shard_checkout https://github.com/icyleaf/halite
@@ -225,7 +249,6 @@ function setup() {
 
 # bats test_tags=format
 @test "format icyleaf/halite" {
-  skip "Formatting not up to date"
   check_crystal_format https://github.com/icyleaf/halite
 }
 
@@ -233,6 +256,11 @@ function setup() {
   shard_checkout https://github.com/jwaldrip/admiral.cr
 
   crystal_spec
+}
+
+# bats test_tags=format
+@test "format jwaldrip/admiral.cr" {
+  check_crystal_format https://github.com/jwaldrip/admiral.cr
 }
 
 @test "jeromegn/slang" {
@@ -244,6 +272,11 @@ function setup() {
   shard_checkout https://github.com/jeromegn/slang
 
   crystal_spec
+}
+
+# bats test_tags=format
+@test "format jeromegn/slang" {
+  check_crystal_format https://github.com/jeromegn/slang
 }
 
 @test "vladfaust/time_format.cr" {
@@ -277,7 +310,6 @@ function setup() {
 
 # bats test_tags=format
 @test "format crystal-community/msgpack-crystal" {
-  skip "Formatting not up to date"
   check_crystal_format https://github.com/crystal-community/msgpack-crystal
 }
 
@@ -288,10 +320,20 @@ function setup() {
   crystal_spec
 }
 
+# bats test_tags=format
+@test "format spider-gazelle/openssl_ext" {
+  check_crystal_format https://github.com/spider-gazelle/openssl_ext
+}
+
 @test "gdotdesign/cr-dotenv" {
   shard_checkout https://github.com/gdotdesign/cr-dotenv
 
   crystal_spec
+}
+
+# bats test_tags=format
+@test "format gdotdesign/cr-dotenv" {
+  check_crystal_format https://github.com/gdotdesign/cr-dotenv
 }
 
 @test "maiha/pretty.cr" {
@@ -303,7 +345,6 @@ function setup() {
 
 # bats test_tags=format
 @test "format maiha/pretty.cr" {
-  skip "Formatting not up to date"
   check_crystal_format https://github.com/maiha/pretty.cr
 }
 


### PR DESCRIPTION
For testing formatter changes we previously skipped code bases that were not already properly formatted because they would report formatter errors unrelated to the particular changes being tested.

But we actually don't need the codebase to be pre-formatted. We can run a baseline formatter first and then see if there are any changes against that.

This patch introduces a second Crystal compiler that serves as the baseline (defined by `$CRYSTAL_BASE`).
If a baseline compiler is available, we first run `$CRYSTAL_BASE tool format` and then only consider changes that `$CRYSTAL tool format` produces against that baseline.

CI installs the baseline compiler in `/tmp/crystal-baseline/`.

This allows us to run formatter tests against any code base, regardless of whether it's already well-formatted or not. This increases the potential surface area a lot.
At this point we can probably extract the individual formatter test definitions from the `bats` files and just iterate a long list of repository URLs.
