### PR TITLE
Switch to `bats-core/bats-action`

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -36,7 +36,7 @@ jobs:
           shards: ${{ inputs.shards || 'nightly' }}
 
       - name: Setup BATS
-        uses: mig4/setup-bats@v1
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
           bats-version: 1.9.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           crystal: ${{ github.event.inputs.crystal || 'nightly' }}
 
       - name: Setup BATS
-        uses: mig4/setup-bats@v1
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
           bats-version: 1.9.0
 


### PR DESCRIPTION
We're currently using https://github.com/mig4/setup-bats. It hasn't been updated in years and looks abandoned, and produces deprecation warnings for Node 20.
https://github.com/bats-core/bats-action is provided by the official bats org and seems to be actively maintained.