### PR TITLE
Download shards into scoped temporary paths

### DIFF
--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -16,7 +16,14 @@ export GIT_TERMINAL_PROMPT=0
 
 function git_checkout() {
   local URL="$1"
-  local TARGET="$BATS_TMPDIR/workdir/${1##*/}"
+  # Transform URL into a filesystem path, stripping the protocol and replacing special characters with underscores
+  local LOCAL_PATH
+  LOCAL_PATH="$(printf '%s' "$URL" |
+    sed -E '
+      s#^[a-zA-Z]+://##;
+      s#[?&=:#]#_#g
+    ')"
+  local TARGET="$BATS_TMPDIR/workdir/${LOCAL_PATH}"
 
   echo "==> Checking out $URL to $TARGET"
 


### PR DESCRIPTION
Previously, the temporary path consisted only of the last component of the URL path, which is typically the shard name. But these names are not unique, which could lead to conflicts that two different repos are downloaded to the same path.