### PR TITLE
Use `shard_checkout` helper in athena tests

### DIFF
--- a/test/athena.bats
+++ b/test/athena.bats
@@ -3,9 +3,8 @@
 function setup_file() {
   load helper/common.bash
 
-  git_checkout https://github.com/athena-framework/athena
-
-  SHARDS_OVERRIDE=shard.dev.yml $SHARDS install
+  export SHARDS_OVERRIDE=shard.dev.yml
+  shard_checkout https://github.com/athena-framework/athena
 }
 
 function setup() {


### PR DESCRIPTION
The helper skips postinstall which is unnecessary and avoids failures like this one: https://github.com/crystal-lang/test-ecosystem/actions/runs/25520076518/job/74901474125?pr=92